### PR TITLE
Update jekyll and bundle versions in gemspec

### DIFF
--- a/garth-jekyll-theme.gemspec
+++ b/garth-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "garth-jekyll-theme"
-  spec.version       = "1.0.4"
+  spec.version       = "1.0.5"
   spec.authors       = ["David Darnes"]
   spec.email         = ["me@daviddarnes.com"]
 
@@ -15,8 +15,8 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README)}i) }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.6"
+  spec.add_runtime_dependency "jekyll", "~> 4.0.0"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 2.1.2"
 end


### PR DESCRIPTION
Trying to use this theme as a gem on a fresh jekyll install results in the following error:

```
Bundler could not find compatible versions for gem "jekyll":
  In Gemfile:
    jekyll (~> 4.0.0)

    garth-jekyll-theme (~> 1.0.4) was resolved to 1.0.4, which depends on
      jekyll (~> 3.6)
```

This PR fixes the issue by updating the jekyll depencency.